### PR TITLE
Autofix: Setup broken with PyTorch 2.5.x

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install PyTorch
-pip install torch
+pip install torch==2.4.0
 
 # Install wheel, packaging, and ninja
 pip install wheel packaging ninja


### PR DESCRIPTION
Modified setup.sh to install PyTorch version 2.4.0 to resolve the undefined symbol issue. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    