### PR TITLE
fix: use correct pydantic le constraint for element_bits

### DIFF
--- a/distillkit/compression/config.py
+++ b/distillkit/compression/config.py
@@ -49,7 +49,7 @@ class QuantizationBin(BaseModel):
         ...,
         description="Number of bits per element.",
         gt=0,
-        lte=64,
+        le=64,
     )
     num_elements: int = Field(
         ...,


### PR DESCRIPTION
## What changed
- Replaced `lte=64` with `le=64` in `QuantizationBin.element_bits` (`distillkit/compression/config.py`).

## Why
- In Pydantic v2, `le` is the valid keyword for "less than or equal" constraints.
- `lte` is treated as an extra/unknown Field argument, which triggers a deprecation warning and does not enforce the intended bound.
- This change preserves the intended validation behavior (`element_bits <= 64`) and removes the warning noise.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`
  - Result: `10 passed in 3.20s`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line Pydantic field constraint fix that restores the intended `element_bits <= 64` validation and removes deprecation/extra-arg warnings.
> 
> **Overview**
> Fixes `QuantizationBin.element_bits` validation by replacing the Pydantic field constraint `lte=64` with `le=64`, ensuring the `<= 64` bound is actually enforced under Pydantic v2 and avoiding extra/unknown Field-arg warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 579f8faf981bca3fa2ae457da23de73642ccdfd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->